### PR TITLE
Added Ollama and PyCurl Support

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,2 @@
+OLLAMA_URL = 'http://localhost:11434'
+OLLAMA_USAGE='True'

--- a/llm/ollama_utils.py
+++ b/llm/ollama_utils.py
@@ -1,0 +1,102 @@
+import pycurl
+import json 
+import os 
+import requests 
+from io import BytesIO
+from dotenv import load_dotenv
+
+load_dotenv()
+
+OLLAMA_URL = os.getenv("OLLAMA_URL")
+
+def accumulate_response(response):
+    res = ""
+
+    # Check if response is a string
+    if isinstance(response, str):
+        lines = response.split("\n")
+    else:
+        # Assume it's an iterable (like requests.Response)
+        lines = response.iter_lines()
+
+    for line in lines:
+        if isinstance(line, bytes):
+            line = line.decode("utf-8")
+
+        if line.strip():
+            try:
+                chunk = json.loads(line)
+                if not chunk.get("done"):
+                    response_piece = chunk.get("response", "")
+                    res += response_piece
+                    # print(response_piece, end='', flush=True)
+                else:
+                    break
+            except json.JSONDecodeError:
+                # If it's not valid JSON, just add the line to the result
+                res += line + "\n"
+                print(line, end="", flush=True)
+
+    return res
+
+
+def perform_curl_request(url, data, stream=False):
+    buffer = BytesIO()
+    c = pycurl.Curl()
+    c.setopt(c.URL, url)
+    c.setopt(c.POST, 1)
+    c.setopt(c.POSTFIELDS, json.dumps(data))
+    c.setopt(c.HTTPHEADER, ["Content-Type: application/json"])
+
+    accumulated = []
+
+    def write_callback(data):
+        decoded_data = data.decode("utf-8")
+        buffer.write(data)
+        if stream:
+            try:
+                json_data = json.loads(decoded_data)
+                if not json_data.get("done"):
+                    response_piece = json_data.get("response", "")
+                    # print(response_piece, end='', flush=True)
+                    accumulated.append(response_piece)
+            except json.JSONDecodeError:
+                # Handle incomplete JSON data
+                accumulated.append(decoded_data)
+
+    c.setopt(c.WRITEFUNCTION, write_callback)
+
+    try:
+        c.perform()
+    finally:
+        c.close()
+
+    if stream:
+        return "".join(accumulated)
+    else:
+        return accumulate_response(buffer.getvalue().decode("utf-8"))
+
+
+def perform_request(url, data, stream=False, use_pycurl=True, session=None):
+    if use_pycurl:
+        return perform_curl_request(url, data, stream)
+    else:
+        request_func = session.post if session else requests.post
+        response = request_func(url, json=data, stream=stream)
+        return accumulate_response(response)
+    
+def get_ollama_response(prompt, use_pycurl=True):
+   
+    data = {
+                "model": "gemma2:2b",
+                "prompt": prompt,
+                "options": {"temperature": 0.2},
+            }
+    res = perform_request(
+                f"{OLLAMA_URL}/api/generate",
+                data,
+                stream=False,
+                use_pycurl=use_pycurl,
+    
+            )
+    return res

--- a/llm/utils.py
+++ b/llm/utils.py
@@ -44,7 +44,7 @@ def get_llm_response(prompt: str) -> str:
         
         if use_ollama:
             print("Using Ollama")
-            res= get_ollama_response("You are an AI assistant that provides insightful analysis of machine learning models and results, focusing on actionable insights for business decision-makers. "+prompt, use_pycurl=False)
+            res= get_ollama_response("You are an AI assistant that provides insightful analysis of machine learning models and results, focusing on actionable insights for business decision-makers. "+prompt)
             print("Got a response")
             print(res)
             return res

--- a/llm/utils.py
+++ b/llm/utils.py
@@ -5,6 +5,7 @@ try:
     from sklearn.metrics import mean_squared_error, r2_score, accuracy_score, confusion_matrix, classification_report
     import streamlit as st
     import h2o
+    from dotenv import load_dotenv
 
 except ModuleNotFoundError as e:
     import subprocess
@@ -30,30 +31,42 @@ except ModuleNotFoundError as e:
 
 import pandas as pd
 from machine_learning.model_mapping import MODEL_MAPPING
+from llm.ollama_utils import get_ollama_response
+from dotenv import load_dotenv
 
+load_dotenv()
 
 # Load the OpenAI API key from Streamlit secrets
 
-def get_llm_response(prompt: str) -> str:
+def get_llm_response(prompt: str) -> str:    
     try:
-        # Initialize the OpenAI client
-        client = OpenAI(api_key = st.secrets["openai_api_key"])
+        use_ollama = os.getenv("OLLAMA_USAGE") == "True"
+        
+        if use_ollama:
+            print("Using Ollama")
+            res= get_ollama_response("You are an AI assistant that provides insightful analysis of machine learning models and results, focusing on actionable insights for business decision-makers. "+prompt, use_pycurl=False)
+            print("Got a response")
+            print(res)
+            return res
+        else:
+            client = OpenAI(api_key=st.secrets.get("openai_api_key"))
 
-        # Create the chat completion
-        completion = client.chat.completions.create(
-            model="gpt-3.5-turbo",
-            messages=[
-                {"role": "system", "content": "You are an AI assistant that provides insightful analysis of machine learning models and results, focusing on actionable insights for business decision-makers."},
-                {"role": "user", "content": prompt}
-            ],
-            temperature=0
-        )
+            # Create the chat completion
+            completion = client.chat.completions.create(
+                model="gpt-3.5-turbo",
+                messages=[
+                    {"role": "system", "content": "You are an AI assistant that provides insightful analysis of machine learning models and results, focusing on actionable insights for business decision-makers."},
+                    {"role": "user", "content": prompt}
+                ],
+                temperature=0
+            )
 
-        # Return the content of the response
-        return completion.choices[0].message.content
+            # Return the content of the response
+            return completion.choices[0].message.content
     
     except Exception as e:
         return f"Error getting LLM explanation: {str(e)}"
+
 
     
 def suggest_models(use_case: str, problem_type: str, data_head: pd.DataFrame, summary: dict, detailed_stats: pd.DataFrame) -> List[str]:

--- a/requirements.txt
+++ b/requirements.txt
@@ -69,3 +69,4 @@ typing_extensions==4.12.2
 tzdata==2024.1
 urllib3==2.2.2
 watchdog==4.0.2
+pycurl==7.45.3


### PR DESCRIPTION
Added a new file in the `llm` directory named `ollama_utils.py`

The file contains the following 3 functions:

`get_ollama_request()` This function communicates with the local Ollama Server. It takes only one parameter as input which is the User Prompt. Ollama System prompt is assigned via the model file. Please look at Ollama documentation to set a custom system prompt.

The `data` dictionary object contains the `model name`  and `temperature` of the model. The model can communicate with Ollama using both PyCurl and Requests, with PyCurl being the default configuration.

`perform_request` and `perform_curl_request` are both utility functions that integrate pythons native requests and PyCurl communication with the Ollama server respectively.

Communication with the Ollama Server can be toggled using a .env file with the following values:
`OLLAMA_URL = 'http://localhost:11434'
OLLAMA_USAGE='True'
`

Configure this file and its values for your particular use case. 11434 is the default Ollama Server port. If you have multiple Ollama servers of are running a docker image of Ollama change the port number and server IP address accordingly. 

The best model for this task, after much consideration is gemma2:2b. 

Future changes to integrate a front end toggle to allow users to toggle the use of Ollama from the front end. Will require the use of a cache such as Flask Sessions or Redis server. Updates will be provided




